### PR TITLE
Fix Build Error C2664 in Visual C++ 6.0 and later.

### DIFF
--- a/External/GDI_drawing.cpp
+++ b/External/GDI_drawing.cpp
@@ -74,7 +74,7 @@ void GDI_drawing::DrawESP(int x, int y, float distance, int health, char name[20
 
 DWORD WINAPI GDI_drawing::esp(Entities entities, Player player, Mathematics math)
 {
-	GetWindowRect(FindWindow(NULL, "AssaultCube"), &m_Rect);
+	GetWindowRect(FindWindow(NULL, L"AssaultCube"), &m_Rect);
 	
 	while (true)
 	{

--- a/External/Main.cpp
+++ b/External/Main.cpp
@@ -25,7 +25,7 @@ int main()
 	GDI_drawing draw(win);
 
 	ShowWindow(FindWindowA("ConsoleWindowClass", NULL), true);
-	draw.TargetWnd = FindWindow(0, "AssaultCube");
+	draw.TargetWnd = FindWindow(0, L"AssaultCube");
 	draw.HDC_Desktop = GetDC(draw.TargetWnd);
 	draw.SetupDrawing(draw.HDC_Desktop, draw.TargetWnd);
 


### PR DESCRIPTION
Fix [Error C2664](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c2664?view=msvc-170)
'HWND FindWindowW(LCWSTR,LPCWSTR)': cannot convert argument 2 from 'const char [12] to ''LPCWSTR'

"In Visual C++ 6.0 and earlier, wchar_t was a typedef for unsigned short and was therefore implicitly convertible to that type. After Visual C++ 6.0, wchar_t is its own built-in type, as specified in the C++ standard, and is no longer implicitly convertible to unsigned short"

by using L it specifies that the string is a wchar_t literal for extended character sets. No more multi-byte character string setting in the project settings.